### PR TITLE
[UPDATE] AUTH AND USER

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-//	implementation 'io.jsonwebtoken:jjwt:0.9.1' // 자바 JWT 라이브러리
 	implementation 'com.auth0:java-jwt:4.2.1'
 	implementation 'javax.xml.bind:jaxb-api:2.3.1' // XML 문서와 Java 객체 간 매핑 자동화
 	implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/src/main/java/com/seulmae/seulmae/global/config/RedisConfig.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/RedisConfig.java
@@ -1,13 +1,20 @@
 package com.seulmae.seulmae.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.cache.CacheManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.cache.RedisCacheConfiguration;
+import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -58,4 +65,18 @@ public class RedisConfig {
         return redisTemplate;
     }
 
+    @Bean
+    public CacheManager oidcCacheManager(RedisConnectionFactory redisConnectionFactory) {
+        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
+                .serializeKeysWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new StringRedisSerializer()))
+                .serializeValuesWith(
+                        RedisSerializationContext.SerializationPair.fromSerializer(
+                                new GenericJackson2JsonRedisSerializer()))
+                .entryTtl(Duration.ofDays(7L));
+        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(redisConnectionFactory)
+                .cacheDefaults(redisCacheConfiguration)
+                .build();
+    }
 }

--- a/src/main/java/com/seulmae/seulmae/global/config/SecurityConfig.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/SecurityConfig.java
@@ -77,10 +77,15 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.POST, "/api/users/sms-certification/send").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users/sms-certification/confirm").permitAll()
                         .requestMatchers(HttpMethod.POST, "/api/users/id/duplication").permitAll()
-//                        .requestMatchers(HttpMethod.POST, "/api/users/email/search").permitAll()
                         .requestMatchers(HttpMethod.PUT, "/api/users/pw").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/version/**").permitAll()
-                        .requestMatchers(new AntPathRequestMatcher("/api/**")).authenticated()
+
+                        .requestMatchers(HttpMethod.PUT,"/api/users/extra-profile").hasRole("GUEST")
+
+                        // 다른 인증된 유저들만 /api/**에 접근 가능하며 GUEST는 제외
+                        .requestMatchers(new AntPathRequestMatcher("/api/**")).hasAnyRole("USER", "ADMIN")
+//                        .requestMatchers(new AntPathRequestMatcher("/api/**")).authenticated()
+
                         .anyRequest().permitAll()) //여기 부분 다시 고민해보자
 //                .oauth2Login(oauth2 -> oauth2
 //                        .successHandler(oAuth2LoginSuccessHandler)

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/OICDPublicKey.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/OICDPublicKey.java
@@ -1,21 +1,16 @@
-package com.seulmae.seulmae.global.config.oauth2.apple;
+package com.seulmae.seulmae.global.config.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Getter;
 
 @Getter
-public class ApplePublicKey {
+public class OICDPublicKey {
     private final String kty;
-
     private final String kid;
-
-    private final String use;
-
     private final String alg;
-
+    private final String use;
     private final String n;
-
     private final String e;
 
     public boolean isSameAlg(final String alg) {
@@ -27,16 +22,16 @@ public class ApplePublicKey {
     }
 
     @JsonCreator
-    public ApplePublicKey(@JsonProperty("kty") final String kty,
-                          @JsonProperty("kid") final String kid,
-                          @JsonProperty("use") final String use,
-                          @JsonProperty("alg") final String alg,
-                          @JsonProperty("n") final String n,
-                          @JsonProperty("e") final String e) {
+    public OICDPublicKey(@JsonProperty("kty") final String kty,
+                         @JsonProperty("kid") final String kid,
+                         @JsonProperty("alg") final String alg,
+                         @JsonProperty("use") final String use,
+                         @JsonProperty("n") final String n,
+                         @JsonProperty("e") final String e) {
         this.kty = kty;
         this.kid = kid;
-        this.use = use;
         this.alg = alg;
+        this.use = use;
         this.n = n;
         this.e = e;
     }

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/apple/AppleOICDPublicKey.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/apple/AppleOICDPublicKey.java
@@ -1,0 +1,44 @@
+package com.seulmae.seulmae.global.config.oauth2.apple;
+
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+
+//@Getter
+public class AppleOICDPublicKey extends OICDPublicKey {
+    public AppleOICDPublicKey(String kty, String kid, String alg, String use, String n, String e) {
+        super(kty, kid, alg, use, n, e);
+    }
+//    private final String kty;
+//
+//    private final String kid;
+//
+//    private final String use;
+//
+//    private final String alg;
+//
+//    private final String n;
+//
+//    private final String e;
+//
+//    public boolean isSameAlg(final String alg) {
+//        return this.alg.equals(alg);
+//    }
+//
+//    public boolean isSameKid(final String kid) {
+//        return this.kid.equals(kid);
+//    }
+//
+//    @JsonCreator
+//    public ApplePublicKey(@JsonProperty("kty") final String kty,
+//                          @JsonProperty("kid") final String kid,
+//                          @JsonProperty("use") final String use,
+//                          @JsonProperty("alg") final String alg,
+//                          @JsonProperty("n") final String n,
+//                          @JsonProperty("e") final String e) {
+//        this.kty = kty;
+//        this.kid = kid;
+//        this.use = use;
+//        this.alg = alg;
+//        this.n = n;
+//        this.e = e;
+//    }
+}

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/kakao/KakaoOICDPublicKey.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/kakao/KakaoOICDPublicKey.java
@@ -1,0 +1,11 @@
+package com.seulmae.seulmae.global.config.oauth2.kakao;
+
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+
+
+public class KakaoOICDPublicKey extends OICDPublicKey {
+
+    public KakaoOICDPublicKey(String kty, String kid, String alg, String use, String n, String e) {
+        super(kty, kid, alg, use, n, e);
+    }
+}

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/userInfo/KakaoOAuth2UserInfo.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/userInfo/KakaoOAuth2UserInfo.java
@@ -14,18 +14,20 @@ public class KakaoOAuth2UserInfo extends OAuth2UserInfo{
 
     @Override
     public String getImageURL() {
-        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
-
-        if (account == null) {
-            return null;
-        }
-
-        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
-
-        if (profile == null) {
-            return null;
-        }
-
-        return (String) profile.get("thumbnail_image_url");
+        return String.valueOf(attributes.get("picture"));
     }
+//        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+//
+//        if (account == null) {
+//            return null;
+//        }
+//
+//        Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+//
+//        if (profile == null) {
+//            return null;
+//        }
+//
+//        return (String) profile.get("thumbnail_image_url");
+//    }
 }

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/util/IdTokenValidator.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/util/IdTokenValidator.java
@@ -1,0 +1,108 @@
+package com.seulmae.seulmae.global.config.oauth2.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+import com.seulmae.seulmae.user.controller.KakaoClient;
+import com.seulmae.seulmae.user.dto.request.PublicKeysFromOauth;
+import com.seulmae.seulmae.user.service.SocialLoginService;
+import io.jsonwebtoken.*;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class IdTokenValidator {
+    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
+    private static final int HEADER_INDEX = 0;
+    private static final int PAYLOAD_INDEX = 1;
+    private static final String KEY_ID_HEADER = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+
+
+    private final ObjectMapper objectMapper;
+
+    /**
+     * 페이로드 검증
+     * 1. id 토큰의 영역 구분자인 온점(.)을 기준으로 페이로드 뽑아내기(인덱스 1)
+     * 2. 페이로드를 Base64 방식으로 DECODING
+     * 3. 페이로드의 키별 값 검증
+     * 3-1. iss: https://kauth.kakao.com 또는 https://appleid.apple.com와 일치해야 함
+     * 3-2. aud: 서비스 앱 키(카카오) 또는 클라이언트 아이디(애플)와 일치해야 함
+     * 3-3. exp: 현재 UNIX 타임스탬프보다 큰 값 필요(ID 토큰 만료 여부 확인)
+     * 3-4. nonce: 카카오 로그인 요청시 전달한 값과 일치해야 함
+     */
+    private Map<String, String> parsePayload(final String idToken) {
+        try {
+            final String encodedPayload = idToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[PAYLOAD_INDEX];
+            final String decodedPayload = new String(Base64.getUrlDecoder().decode(encodedPayload));
+            return objectMapper.readValue(decodedPayload, Map.class);
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("idToken 값이 jwt 형식인지, 값이 정상적인지 확인해주세요.");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("디코딩된 페이로드를 Map 형태로 분류할 수 없습니다. 페이로드를 확인해주세요.");
+        }
+    }
+
+    public Jwt<Header, Claims> validatePayloadClaims(String idToken, String iss, String aud) {
+        try {
+            return Jwts.parser()
+                    .requireAudience(aud)
+                    .requireIssuer(iss)
+                    .build()
+                    .parseUnsecuredClaims(parsePayload(idToken).get("decodedPayload"));
+        } catch (ExpiredJwtException e) {
+            throw new RuntimeException("ID 토큰이 만료됐습니다");
+        } catch (Exception e) {
+            log.error(e.toString());
+            throw new RuntimeException("유효하지 않는 ID 토큰입니다");
+        }
+    }
+
+    /**
+     * 서명 검증
+     * 1. id 토큰의 영역 구분자인 온점(.)을 기준으로 헤더, 서명 뽑아내기(인덱스 0, 2)
+     * 2. 헤더를 Base64 방식으로 디코딩
+     * 3. OIDC: 공개키 목록 조회하기 API로 카카오 인증 서버가 서명 시 사용하는 공개키 목록 조회
+     * 4. 공개키 목록에서 헤더의 kid에 해당하는 공개키 값 확인
+     * 5. JWT 서명 검증을 지원하는 라이브러리를 사용해 공개키로 서명 검증
+     */
+
+    private Map<String, String> parseHeader(final String idToken) {
+        try {
+            final String encodedHeader = idToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+            return objectMapper.readValue(decodedHeader, Map.class);
+        } catch (JsonMappingException e) {
+            throw new RuntimeException("idToken 값이 jwt 형식인지, 값이 정상적인지 확인해주세요.");
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("디코드된 헤더를 Map 형태로 분류할 수 없습니다. 헤더를 확인해주세요.");
+        }
+    }
+
+    // 공개키로 토큰 검증을 시도하고 클레임을 추출한다.
+    public Claims extractClaims(String idToken, PublicKeysFromOauth<OICDPublicKey> publicKeys) {
+        try {
+            return Jwts.parser()
+                    .verifyWith(PublicKeyProvider.generate(parseHeader(idToken), publicKeys))
+                    .build()
+                    .parseSignedClaims(idToken)
+                    .getPayload();
+        } catch (UnsupportedJwtException e) {
+            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("비어있는 jwt");
+        } catch (JwtException e) {
+            throw new JwtException("jwt 검증 or 분석 오류");
+        }
+    }
+}

--- a/src/main/java/com/seulmae/seulmae/global/config/oauth2/util/PublicKeyProvider.java
+++ b/src/main/java/com/seulmae/seulmae/global/config/oauth2/util/PublicKeyProvider.java
@@ -1,0 +1,46 @@
+package com.seulmae.seulmae.global.config.oauth2.util;
+
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+import com.seulmae.seulmae.global.config.oauth2.kakao.KakaoOICDPublicKey;
+import com.seulmae.seulmae.user.dto.request.PublicKeysFromOauth;
+import org.springframework.stereotype.Component;
+
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.Map;
+
+@Component
+public class PublicKeyProvider {
+    private static final String SIGN_ALGORITHM_HEADER = "alg";
+    private static final String KEY_ID_HEADER = "kid";
+    private static final int POSITIVE_SIGN_NUMBER = 1;
+
+    public static PublicKey generate(Map<String, String> header, PublicKeysFromOauth<OICDPublicKey> publicKeys) {
+        final OICDPublicKey oicdPublicKey = publicKeys.getMatchingKey(
+                header.get(SIGN_ALGORITHM_HEADER),
+                header.get(KEY_ID_HEADER)
+        );
+        return generatePublicKey(oicdPublicKey);
+    }
+
+    private static PublicKey generatePublicKey(OICDPublicKey oicdPublicKey) {
+        final byte[] nBytes = Base64.getUrlDecoder().decode(oicdPublicKey.getN());
+        final byte[] eBytes = Base64.getUrlDecoder().decode(oicdPublicKey.getE());
+
+        final BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+        final BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+
+        try {
+            final KeyFactory keyFactory = KeyFactory.getInstance(oicdPublicKey.getKty());
+            return keyFactory.generatePublic(rsaPublicKeySpec);
+        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+            throw new RuntimeException("잘못된 퍼블릭 키입니다.");
+        }
+    }
+}

--- a/src/main/java/com/seulmae/seulmae/global/util/FileUtil.java
+++ b/src/main/java/com/seulmae/seulmae/global/util/FileUtil.java
@@ -124,12 +124,33 @@ public class FileUtil {
         try {
             URL urlObj = new URL(url);
             String path = urlObj.getPath();
+            /** 수정한 부분 **/
+            String query = urlObj.getQuery();
+
+            if (query != null && query.contains("fname=")) {
+                String fname = extractFname(query);
+                System.out.println("fname = " + fname);
+                return fname.substring(fname.lastIndexOf('/') + 1);
+            }
+
+            /** 수정 마지막 부분 **/
+
             return path.substring(path.lastIndexOf('/') + 1);
         } catch (MalformedURLException e) {
             throw new RuntimeException("Invalid URL: " + url, e);
         }
     }
 
+    private static String extractFname(String url) {
+        String keyword = "fname=";
+        int startIndex = url.indexOf(keyword);
+
+        if (startIndex != -1) { // fname=이 존재하는 경우
+            return url.substring(startIndex + keyword.length());
+        } else {
+            throw new RuntimeException("URL에 fname 파라미터가 없습니다.");
+        }
+    }
 
     private static String checkMimeType(File file, String path) {
         String mimeType = getMimeType(file);

--- a/src/main/java/com/seulmae/seulmae/global/util/ResponseUtil.java
+++ b/src/main/java/com/seulmae/seulmae/global/util/ResponseUtil.java
@@ -28,7 +28,7 @@ public class ResponseUtil {
             return createErrorResponse(ErrorCode.FORBIDDEN_ERROR, e.getMessage());
         } else if (e instanceof AuthenticationException) {
             return createErrorResponse(ErrorCode.UNAUTHORIZED, e.getMessage());
-        } else if (e instanceof IllegalArgumentException) {
+        } else if (e instanceof IllegalArgumentException || e instanceof IllegalStateException) {
             return createErrorResponse(ErrorCode.BAD_REQUEST_ERROR, e.getMessage());
         } else if (e instanceof NoSuchElementException) {
             return createErrorResponse(ErrorCode.NOT_FOUND_ERROR, e.getMessage());

--- a/src/main/java/com/seulmae/seulmae/notification/service/NotificationService.java
+++ b/src/main/java/com/seulmae/seulmae/notification/service/NotificationService.java
@@ -93,11 +93,11 @@ public class NotificationService {
             fcmIndividualServiceImpl.sendMultiMessageTo(fcmTokens, title, body, type, id, workplaceId);
 
         } catch (FirebaseMessagingException e) {
-            log.error("Failed to send FCM message to user {} with title '{}'", receiver.getUsername(), title, e);
+            log.error("Failed to send FCM message to user {} with title '{}'", receiver.getAccountId(), title, e);
 
             throw new RuntimeException("Failed to send FCM message", e);
         } catch (Exception e) {
-            log.error("An error occurred while sending message to user {} with title '{}'", receiver.getUsername(), title, e);
+            log.error("An error occurred while sending message to user {} with title '{}'", receiver.getAccountId(), title, e);
             throw new RuntimeException("Failed to send message", e);
         }
     }

--- a/src/main/java/com/seulmae/seulmae/user/controller/KakaoClient.java
+++ b/src/main/java/com/seulmae/seulmae/user/controller/KakaoClient.java
@@ -1,0 +1,14 @@
+package com.seulmae.seulmae.user.controller;
+
+import com.seulmae.seulmae.user.dto.request.KakaoPublicKeysFromKaKao;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@FeignClient(name = "kakao-public-key",
+        url = "https://kauth.kakao.com")
+public interface KakaoClient {
+    @Cacheable(cacheNames = "KakaoPublicKeys", cacheManager = "oidcCacheManager")
+    @GetMapping("/.well-known/jwks.json")
+    KakaoPublicKeysFromKaKao getKakaoOICDOpenKeys();
+}

--- a/src/main/java/com/seulmae/seulmae/user/controller/UserController.java
+++ b/src/main/java/com/seulmae/seulmae/user/controller/UserController.java
@@ -133,6 +133,21 @@ public class UserController {
     }
 
     /**
+     * 휴대폰 번호 변경 관련 인증번호 신청
+     */
+
+    @PostMapping("/sms-certification/send/phone")
+    public ResponseEntity<?> sendSMS(@RequestBody SmsSendingRequest request,
+                                     @AuthenticationPrincipal User user) {
+        try {
+            FindAuthResponse result = userService.sendSMSCertification(request, user);
+            return ResponseUtil.createSuccessResponse(SuccessCode.SEND_SMS_SUCCESS, result);
+        } catch (Exception e) {
+            return ResponseUtil.handleException(e);
+        }
+    }
+
+    /**
      * 휴대폰 인증번호 확인
      *
      * @param request
@@ -147,6 +162,21 @@ public class UserController {
             return ResponseUtil.handleException(e);
         }
     }
+
+    /**
+     * 휴대폰 번호 변경 관련 인증번호 확인
+     */
+    @PostMapping("/sms-certification/confirm/phone")
+    public ResponseEntity<?> verifySMS(@RequestBody SmsCertificationRequest request,
+                                       @AuthenticationPrincipal User user) {
+        try {
+            FindAuthResponse result = userService.confirmSMSCertification(request, user);
+            return ResponseUtil.createSuccessResponse(SuccessCode.VERIFY_SMS_SUCCESS, result);
+        } catch (Exception e) {
+            return ResponseUtil.handleException(e);
+        }
+    }
+
 
     /**
      * 소셜로그인 추가 정보 업데이트

--- a/src/main/java/com/seulmae/seulmae/user/dto/request/KakaoPublicKeysFromKaKao.java
+++ b/src/main/java/com/seulmae/seulmae/user/dto/request/KakaoPublicKeysFromKaKao.java
@@ -1,6 +1,6 @@
 package com.seulmae.seulmae.user.dto.request;
 
-import com.seulmae.seulmae.global.config.oauth2.apple.AppleOICDPublicKey;
+import com.seulmae.seulmae.global.config.oauth2.kakao.KakaoOICDPublicKey;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -8,15 +8,16 @@ import java.util.List;
 
 @Getter
 @NoArgsConstructor
-public class ApplePublicKeysFromApple implements PublicKeysFromOauth<AppleOICDPublicKey>  {
+public class KakaoPublicKeysFromKaKao implements PublicKeysFromOauth<KakaoOICDPublicKey> {
 
-    private List<AppleOICDPublicKey> keys;
+    private List<KakaoOICDPublicKey> keys;
 
-    public ApplePublicKeysFromApple(List<AppleOICDPublicKey> keys) {
+    public KakaoPublicKeysFromKaKao(List<KakaoOICDPublicKey> keys) {
         this.keys = List.copyOf(keys);
     }
+
     @Override
-    public AppleOICDPublicKey getMatchingKey(final String alg, final String kid) {
+    public KakaoOICDPublicKey getMatchingKey(String alg, String kid) {
         return keys.stream()
                 .filter(key -> key.isSameAlg(alg) && key.isSameKid(kid))
                 .findFirst()

--- a/src/main/java/com/seulmae/seulmae/user/dto/request/PublicKeysFromOauth.java
+++ b/src/main/java/com/seulmae/seulmae/user/dto/request/PublicKeysFromOauth.java
@@ -1,0 +1,13 @@
+package com.seulmae.seulmae.user.dto.request;
+
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+
+import java.util.List;
+
+public interface PublicKeysFromOauth<T extends OICDPublicKey>  {
+    List<T> getKeys();
+
+    T getMatchingKey(final String alg, final String kid);
+
+}
+

--- a/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingForPasswordRequest.java
+++ b/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingForPasswordRequest.java
@@ -1,8 +1,0 @@
-package com.seulmae.seulmae.user.dto.request;
-
-import lombok.Getter;
-
-@Getter
-public class SmsSendingForPasswordRequest extends SmsSendingRequest {
-    private String accountId;
-}

--- a/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingRequest.java
+++ b/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingRequest.java
@@ -8,6 +8,7 @@ import lombok.Setter;
 @Setter
 public class SmsSendingRequest {
     private SmsSendingType sendingType;
+    private String name;
     private String phoneNumber;
     private String accountId;
 

--- a/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingRequest.java
+++ b/src/main/java/com/seulmae/seulmae/user/dto/request/SmsSendingRequest.java
@@ -10,7 +10,6 @@ public class SmsSendingRequest {
     private SmsSendingType sendingType;
     private String name;
     private String phoneNumber;
-    private String accountId;
 
     public String setPhoneNumber(String phoneNumber) {
         this.phoneNumber = phoneNumber.replaceAll("-", "");

--- a/src/main/java/com/seulmae/seulmae/user/entity/User.java
+++ b/src/main/java/com/seulmae/seulmae/user/entity/User.java
@@ -69,6 +69,7 @@ public class User implements UserDetails {
     @Column(name = "refresh_token")
     private String refreshToken;
 
+    @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<FcmToken> fcmTokens = new HashSet<>();
 

--- a/src/main/java/com/seulmae/seulmae/user/entity/User.java
+++ b/src/main/java/com/seulmae/seulmae/user/entity/User.java
@@ -201,11 +201,9 @@ public class User implements UserDetails {
     }
 
     /** 유효성 검사 **/
-
-
     @Override
-    public Collection<? extends GrantedAuthority> getAuthorities() {
-        return List.of(new SimpleGrantedAuthority("user"));
+    public Collection<GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority("ROLE_" + this.authorityRole.name()));
     }
 
     @Override

--- a/src/main/java/com/seulmae/seulmae/user/entity/User.java
+++ b/src/main/java/com/seulmae/seulmae/user/entity/User.java
@@ -20,7 +20,9 @@ import java.util.*;
 
 @Entity
 @Getter
-@Table(name = "users")
+@Table(name = "users", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"phone_number", "name"})
+})
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @EntityListeners(AuditingEntityListener.class)
 @AllArgsConstructor
@@ -34,7 +36,7 @@ public class User implements UserDetails {
     @Column(name = "account_id", unique = true)
     private String accountId;
 
-    @Column(name = "phone_number", unique = true)
+    @Column(name = "phone_number")
     private String phoneNumber;
 
     @Column(name = "password")

--- a/src/main/java/com/seulmae/seulmae/user/entity/UserImage.java
+++ b/src/main/java/com/seulmae/seulmae/user/entity/UserImage.java
@@ -39,15 +39,15 @@ public class UserImage {
     @Column(name = "reg_date_user_image")
     private LocalDateTime regDateUserImage;
 
-    @LastModifiedDate
-    @Column(name = "revision_date_user_image")
-    private LocalDateTime revisionDateUserImage;
-
-    @Column(name = "is_del_user_image")
-    private Boolean isDelUserImage = false;
-
-    @Column(name = "del_date_user_image")
-    private LocalDateTime delDateUserImage;
+//    @LastModifiedDate
+//    @Column(name = "revision_date_user_image")
+//    private LocalDateTime revisionDateUserImage;
+//
+//    @Column(name = "is_del_user_image")
+//    private Boolean isDelUserImage = false;
+//
+//    @Column(name = "del_date_user_image")
+//    private LocalDateTime delDateUserImage;
 
     public UserImage(User user, String userImageName, String userImagePath, String userImageExtension) {
         this.user = user;
@@ -62,10 +62,10 @@ public class UserImage {
         this.userImageExtension = userImageExtension;
     }
 
-    public void delete() {
-        this.isDelUserImage = true;
-        this.delDateUserImage = LocalDateTime.now();
-    }
+//    public void delete() {
+//        this.isDelUserImage = true;
+//        this.delDateUserImage = LocalDateTime.now();
+//    }
 
 
 }

--- a/src/main/java/com/seulmae/seulmae/user/enums/SmsSendingType.java
+++ b/src/main/java/com/seulmae/seulmae/user/enums/SmsSendingType.java
@@ -1,10 +1,10 @@
 package com.seulmae.seulmae.user.enums;
 
 public enum SmsSendingType {
-    SIGNUP("signUp"),
-    FIND_ACCOUNT_ID("findAccountId"),
-    FIND_PW("findPassword"),
-    CHANGE_PHONE_NUM("changePhoneNumber");
+    SIGNUP("회원가입"),
+    FIND_ACCOUNT_ID("아이디 찾기"),
+    CHANGE_PW("비밀번호 재설정"),
+    CHANGE_PHONE_NUM("휴대폰번호 변경");
     private String sendingType;
 
     SmsSendingType(String sendingType) {

--- a/src/main/java/com/seulmae/seulmae/user/repository/UserRepository.java
+++ b/src/main/java/com/seulmae/seulmae/user/repository/UserRepository.java
@@ -11,6 +11,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByPhoneNumber(String phoneNumber);
 
+    boolean existsByNameAndPhoneNumber(String name, String phoneNumber);
+
     boolean existsByAccountIdAndPhoneNumber(String accountId, String phoneNumber);
 
     boolean existsByAccountIdAndIsDelUserTrue(String accountId);

--- a/src/main/java/com/seulmae/seulmae/user/service/AppleService.java
+++ b/src/main/java/com/seulmae/seulmae/user/service/AppleService.java
@@ -3,7 +3,9 @@ package com.seulmae.seulmae.user.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.seulmae.seulmae.global.config.oauth2.apple.ApplePublicKey;
+import com.seulmae.seulmae.global.config.oauth2.apple.AppleOICDPublicKey;
+import com.seulmae.seulmae.global.config.oauth2.util.IdTokenValidator;
+import com.seulmae.seulmae.user.dto.request.PublicKeysFromOauth;
 import com.seulmae.seulmae.user.enums.SocialType;
 import com.seulmae.seulmae.user.controller.AppleClient;
 import com.seulmae.seulmae.user.dto.request.ApplePublicKeysFromApple;
@@ -14,6 +16,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.UnsupportedJwtException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.math.BigInteger;
@@ -29,84 +32,92 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class AppleService {
-    private static final String IDENTITY_TOKEN_VALUE_DELIMITER = "\\.";
-    private static final int HEADER_INDEX = 0;
-    private static final String SIGN_ALGORITHM_HEADER = "alg";
-    private static final String KEY_ID_HEADER = "kid";
-    private static final int POSITIVE_SIGN_NUMBER = 1;
+    @Value("${social-login.provider.apple.client-id}")
+    private String APPLE_AUD;
+    private static final String APPLE_ISS = "https://appleid.apple.com";
     private static final String CLAIM_ID = "sub";
 
 
-    private final ObjectMapper objectMapper;
     private final AppleClient appleClient;
     private final SocialLoginService socialLoginService;
-
-    public User getUserInfo(String identityToken, String provider) {
-        final Map<String, String> appleTokenHeader = parseHeader(identityToken);
-        final ApplePublicKeysFromApple applePublicKeys = appleClient.getApplePublicKeys();
-        final PublicKey publicKey = generate(appleTokenHeader, applePublicKeys);
-        final Map<String, Object> claims = new HashMap<>(extractClaims(identityToken, publicKey));
+    private final IdTokenValidator idTokenValidator;
+    public User getUserInfo(String idToken, String provider) {
+        PublicKeysFromOauth applePublicKeys = appleClient.getApplePublicKeys();
+        // 임시 주석 처리(클라이언트 id를 받을 수 없는 상태)
+//        idTokenValidator.validatePayloadClaims(idToken, APPLE_ISS, APPLE_AUD);
+        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, applePublicKeys));
 
         SocialType socialType = socialLoginService.getSocialType(provider);
-
         OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, claims.get(CLAIM_ID).toString(), claims);
 
         return socialLoginService.getOrCreateUser(extractAttributes, socialType);
     }
-
-    /**
-     * id_token 헤더 추출
-     */
-
-    public Map<String, String> parseHeader(final String appleToken) {
-        try {
-            final String encodedHeader = appleToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
-            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
-            return objectMapper.readValue(decodedHeader, Map.class);
-        } catch (JsonMappingException e) {
-            throw new RuntimeException("appleToken 값이 jwt 형식인지, 값이 정상적인지 확인해주세요.");
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException("디코드된 헤더를 Map 형태로 분류할 수 없습니다. 헤더를 확인해주세요.");
-        }
-    }
-
-    private Claims extractClaims(final String appleToken, final PublicKey publicKey) {
-        try {
-            return Jwts.parser()
-                    .verifyWith(publicKey)
-                    .build()
-                    .parseSignedClaims(appleToken)
-                    .getPayload();
-        } catch (UnsupportedJwtException e) {
-            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
-        } catch (IllegalArgumentException e) {
-            throw new IllegalArgumentException("비어있는 jwt");
-        } catch (JwtException e) {
-            throw new JwtException("jwt 검증 or 분석 오류");
-        }
-    }
-
-    private PublicKey generate(final Map<String, String> headers, final ApplePublicKeysFromApple publicKeys) {
-        final ApplePublicKey applePublicKey = publicKeys.getMatchingKey(
-                headers.get(SIGN_ALGORITHM_HEADER),
-                headers.get(KEY_ID_HEADER)
-        );
-        return generatePublicKey(applePublicKey);
-    }
-
-    private PublicKey generatePublicKey(final ApplePublicKey applePublicKey) {
-        final byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.getN());
-        final byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.getE());
-
-        final BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
-        final BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
-        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
-
-        try {
-            final KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
-            return keyFactory.generatePublic(rsaPublicKeySpec);
-        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
-            throw new RuntimeException("잘못된 애플 키");
-        }
-    }
+//    public User getUserInfo(String identityToken, String provider) {
+//        final Map<String, String> appleTokenHeader = parseHeader(identityToken);
+//        final ApplePublicKeysFromApple applePublicKeys = appleClient.getApplePublicKeys();
+//        final PublicKey publicKey = generate(appleTokenHeader, applePublicKeys);
+//        final Map<String, Object> claims = new HashMap<>(extractClaims(identityToken, publicKey));
+//
+//        SocialType socialType = socialLoginService.getSocialType(provider);
+//
+//        OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, claims.get(CLAIM_ID).toString(), claims);
+//
+//        return socialLoginService.getOrCreateUser(extractAttributes, socialType);
+//    }
+//
+//    /**
+//     * id_token 헤더 추출
+//     */
+//
+//    public Map<String, String> parseHeader(final String appleToken) {
+//        try {
+//            final String encodedHeader = appleToken.split(IDENTITY_TOKEN_VALUE_DELIMITER)[HEADER_INDEX];
+//            final String decodedHeader = new String(Base64.getUrlDecoder().decode(encodedHeader));
+//            return objectMapper.readValue(decodedHeader, Map.class);
+//        } catch (JsonMappingException e) {
+//            throw new RuntimeException("idToken 값이 jwt 형식인지, 값이 정상적인지 확인해주세요.");
+//        } catch (JsonProcessingException e) {
+//            throw new RuntimeException("디코드된 헤더를 Map 형태로 분류할 수 없습니다. 헤더를 확인해주세요.");
+//        }
+//    }
+//
+//    private Claims extractClaims(final String appleToken, final PublicKey publicKey) {
+//        try {
+//            return Jwts.parser()
+//                    .verifyWith(publicKey)
+//                    .build()
+//                    .parseSignedClaims(appleToken)
+//                    .getPayload();
+//        } catch (UnsupportedJwtException e) {
+//            throw new UnsupportedJwtException("지원되지 않는 jwt 타입");
+//        } catch (IllegalArgumentException e) {
+//            throw new IllegalArgumentException("비어있는 jwt");
+//        } catch (JwtException e) {
+//            throw new JwtException("jwt 검증 or 분석 오류");
+//        }
+//    }
+//
+//    private PublicKey generate(final Map<String, String> headers, final ApplePublicKeysFromApple publicKeys) {
+//        final AppleOICDPublicKey applePublicKey = publicKeys.getMatchingKey(
+//                headers.get(SIGN_ALGORITHM_HEADER),
+//                headers.get(KEY_ID_HEADER)
+//        );
+//        return generatePublicKey(applePublicKey);
+//    }
+//
+//    private PublicKey generatePublicKey(final AppleOICDPublicKey applePublicKey) {
+//        final byte[] nBytes = Base64.getUrlDecoder().decode(applePublicKey.getN());
+//        final byte[] eBytes = Base64.getUrlDecoder().decode(applePublicKey.getE());
+//
+//        final BigInteger n = new BigInteger(POSITIVE_SIGN_NUMBER, nBytes);
+//        final BigInteger e = new BigInteger(POSITIVE_SIGN_NUMBER, eBytes);
+//        final RSAPublicKeySpec rsaPublicKeySpec = new RSAPublicKeySpec(n, e);
+//
+//        try {
+//            final KeyFactory keyFactory = KeyFactory.getInstance(applePublicKey.getKty());
+//            return keyFactory.generatePublic(rsaPublicKeySpec);
+//        } catch (NoSuchAlgorithmException | InvalidKeySpecException exception) {
+//            throw new RuntimeException("잘못된 애플 키");
+//        }
+//    }
 }

--- a/src/main/java/com/seulmae/seulmae/user/service/AppleService.java
+++ b/src/main/java/com/seulmae/seulmae/user/service/AppleService.java
@@ -45,7 +45,7 @@ public class AppleService {
         PublicKeysFromOauth applePublicKeys = appleClient.getApplePublicKeys();
         // 임시 주석 처리(클라이언트 id를 받을 수 없는 상태)
 //        idTokenValidator.validatePayloadClaims(idToken, APPLE_ISS, APPLE_AUD);
-        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, applePublicKeys));
+        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, APPLE_AUD, APPLE_ISS, applePublicKeys));
 
         SocialType socialType = socialLoginService.getSocialType(provider);
         OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, claims.get(CLAIM_ID).toString(), claims);

--- a/src/main/java/com/seulmae/seulmae/user/service/KakaoService.java
+++ b/src/main/java/com/seulmae/seulmae/user/service/KakaoService.java
@@ -1,35 +1,18 @@
 package com.seulmae.seulmae.user.service;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
-import com.seulmae.seulmae.global.config.oauth2.kakao.KakaoOICDPublicKey;
 import com.seulmae.seulmae.global.config.oauth2.util.IdTokenValidator;
 import com.seulmae.seulmae.user.controller.KakaoClient;
-import com.seulmae.seulmae.user.dto.request.KakaoPublicKeysFromKaKao;
 import com.seulmae.seulmae.user.dto.request.OAuthAttributesDto;
 import com.seulmae.seulmae.user.dto.request.PublicKeysFromOauth;
 import com.seulmae.seulmae.user.entity.User;
 import com.seulmae.seulmae.user.enums.SocialType;
-import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import org.springframework.web.client.RestTemplate;
 
-import java.math.BigInteger;
-import java.security.KeyFactory;
-import java.security.NoSuchAlgorithmException;
-import java.security.PublicKey;
-import java.security.spec.InvalidKeySpecException;
-import java.security.spec.RSAPublicKeySpec;
-import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
-
-import static org.apache.http.message.BasicLineParser.parseHeader;
 
 @Service
 @RequiredArgsConstructor
@@ -61,8 +44,7 @@ public class KakaoService {
      */
     public User getUserInfo(String idToken, String provider) {
         PublicKeysFromOauth kakaoPublicKeys = kakaoClient.getKakaoOICDOpenKeys();
-        idTokenValidator.validatePayloadClaims(idToken, KAKAO_ISS, KAKAO_AUD);
-        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, kakaoPublicKeys));
+        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, KAKAO_AUD, KAKAO_ISS, kakaoPublicKeys));
         SocialType socialType = socialLoginService.getSocialType(provider);
         OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, claims.get(CLAIM_ID).toString(), claims);
 

--- a/src/main/java/com/seulmae/seulmae/user/service/KakaoService.java
+++ b/src/main/java/com/seulmae/seulmae/user/service/KakaoService.java
@@ -1,41 +1,89 @@
 package com.seulmae.seulmae.user.service;
 
-import com.seulmae.seulmae.user.enums.SocialType;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.seulmae.seulmae.global.config.oauth2.OICDPublicKey;
+import com.seulmae.seulmae.global.config.oauth2.kakao.KakaoOICDPublicKey;
+import com.seulmae.seulmae.global.config.oauth2.util.IdTokenValidator;
+import com.seulmae.seulmae.user.controller.KakaoClient;
+import com.seulmae.seulmae.user.dto.request.KakaoPublicKeysFromKaKao;
 import com.seulmae.seulmae.user.dto.request.OAuthAttributesDto;
+import com.seulmae.seulmae.user.dto.request.PublicKeysFromOauth;
 import com.seulmae.seulmae.user.entity.User;
+import com.seulmae.seulmae.user.enums.SocialType;
+import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.util.UriComponentsBuilder;
 
+import java.math.BigInteger;
+import java.security.KeyFactory;
+import java.security.NoSuchAlgorithmException;
+import java.security.PublicKey;
+import java.security.spec.InvalidKeySpecException;
+import java.security.spec.RSAPublicKeySpec;
+import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
+
+import static org.apache.http.message.BasicLineParser.parseHeader;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class KakaoService {
-    private final SocialLoginService socialLoginService;
 
-    private final RestTemplate restTemplate;
+    @Value("${social-login.provider.kakao.native-app-key}")
+    private String KAKAO_AUD;
+    private static final String KAKAO_ISS = "https://kauth.kakao.com";
+    private static final String CLAIM_ID = "sub";
+
+    private final SocialLoginService socialLoginService;
+    private final KakaoClient kakaoClient;
+    private final IdTokenValidator idTokenValidator;
+
 
     @Value("${social-login.provider.kakao.user-info-uri}")
     private String USER_INFO_URI;
 
-
-    /** 유저 info를 부르고 user를 반환하는 메서드 **/
-    public User getUserInfo(String token, String provider) {
-        String url = UriComponentsBuilder.fromHttpUrl(USER_INFO_URI)
-                .pathSegment("v2", "user", "me")
-                .toUriString();
-
-        // HTTP GET 요청을 보내고, KakaoUserInfo 객체로 응답을 변환합니다.
-        Map<String, Object> attributes = restTemplate.getForObject(url, Map.class, token);
+    /**
+     * 카카오 소셜 로그인 OICD 이후, 회원가입 또는 회원조회 진행
+     * - ID토큰 유효성 검사
+     * - 페이로드 검증
+     * - 서명 검증
+     *   - 공개키 찾기
+     *   - 공개키 생성
+     *   - 공개키를 이용해서 서명 검증
+     * - 유저 정보 조회
+     */
+    public User getUserInfo(String idToken, String provider) {
+        PublicKeysFromOauth kakaoPublicKeys = kakaoClient.getKakaoOICDOpenKeys();
+        idTokenValidator.validatePayloadClaims(idToken, KAKAO_ISS, KAKAO_AUD);
+        Map<String, Object> claims = new HashMap<>(idTokenValidator.extractClaims(idToken, kakaoPublicKeys));
         SocialType socialType = socialLoginService.getSocialType(provider);
-
-        String socialId = attributes.get("id").toString();
-        OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, socialId, attributes);
+        OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, claims.get(CLAIM_ID).toString(), claims);
 
         return socialLoginService.getOrCreateUser(extractAttributes, socialType);
     }
+
+
+    /** 유저 info를 부르고 user를 반환하는 메서드 **/
+//    public User getUserInfo(String token, String provider) {
+//        String url = UriComponentsBuilder.fromHttpUrl(USER_INFO_URI)
+//                .pathSegment("v2", "user", "me")
+//                .toUriString();
+//
+//        // HTTP GET 요청을 보내고, KakaoUserInfo 객체로 응답을 변환합니다.
+//        Map<String, Object> attributes = restTemplate.getForObject(url, Map.class, token);
+//        SocialType socialType = socialLoginService.getSocialType(provider);
+//
+//        String socialId = attributes.get("id").toString();
+//        OAuthAttributesDto extractAttributes = OAuthAttributesDto.of(socialType, socialId, attributes);
+//
+//        return socialLoginService.getOrCreateUser(extractAttributes, socialType);
+//    }
 
 }

--- a/src/main/java/com/seulmae/seulmae/user/service/UserService.java
+++ b/src/main/java/com/seulmae/seulmae/user/service/UserService.java
@@ -54,7 +54,8 @@ public class UserService {
     public void createUser(UserSignUpDto userSignUpDto, MultipartFile file) {
 
         checkDuplicatedAccountId(userSignUpDto.getAccountId());
-        checkDuplicatedPhoneNumber(userSignUpDto.getPhoneNumber());
+//        checkDuplicatedPhoneNumber(userSignUpDto.getPhoneNumber());
+        checkDuplicatedNameAndPhoneNumber(userSignUpDto.getName(), userSignUpDto.getPhoneNumber());
         checkPasswordValidation(userSignUpDto.getPassword());
         checkAccountIdValidation(userSignUpDto.getAccountId());
 
@@ -131,9 +132,17 @@ public class UserService {
         }
     }
 
+
+    @Deprecated
     public void checkDuplicatedPhoneNumber(String phoneNumber) {
         if (isDuplicatedPhoneNumber(phoneNumber)) {
             throw new IllegalArgumentException("이미 존재하는 휴대폰번호입니다.");
+        }
+    }
+
+    public void checkDuplicatedNameAndPhoneNumber(String name, String phoneNumber) {
+        if (isDuplicatedNameAndPhoneNumber(name, phoneNumber)) {
+            throw new IllegalArgumentException("가입한 계정이 존재합니다.");
         }
     }
 
@@ -157,6 +166,10 @@ public class UserService {
         return userRepository.existsByPhoneNumber(phoneNumber);
     }
 
+    public boolean isDuplicatedNameAndPhoneNumber(String name, String phoneNumber) {
+        return userRepository.existsByNameAndPhoneNumber(name, phoneNumber);
+    }
+
     public boolean isCorrectAccountId(String accountId) {
         // 길이 체크
         if (accountId.length() < 5) {
@@ -175,7 +188,8 @@ public class UserService {
     public void changePhoneNumber(ChangePhoneNumberRequest request, User user) throws AccessDeniedException {
         User me = findByIdUtil.getUserById(user.getIdUser());
 
-        checkDuplicatedPhoneNumber(request.getPhoneNumber());
+//        checkDuplicatedPhoneNumber(request.getPhoneNumber());
+        checkDuplicatedNameAndPhoneNumber(me.getName(), request.getPhoneNumber());
         me.updatePhoneNumber(request.getPhoneNumber());
 
         userRepository.save(me);
@@ -273,7 +287,8 @@ public class UserService {
          */
         if (request.getSendingType().equals(SmsSendingType.SIGNUP) || request.getSendingType().equals(SmsSendingType.CHANGE_PHONE_NUM)) {
 
-            checkDuplicatedPhoneNumber(request.getPhoneNumber());
+//            checkDuplicatedPhoneNumber(request.getPhoneNumber());
+            checkDuplicatedNameAndPhoneNumber(request.getName(), request.getPhoneNumber());
 
             smsService.sendSMS(request.getPhoneNumber());
 
@@ -284,8 +299,12 @@ public class UserService {
          * 아이디 찾기
          */
         if (request.getSendingType().equals(SmsSendingType.FIND_ACCOUNT_ID)) {
-            if (!isDuplicatedPhoneNumber(request.getPhoneNumber())) {
-                throw new IllegalArgumentException("가입된 휴대폰 번호가 아닙니다.");
+//            if (!isDuplicatedPhoneNumber(request.getPhoneNumber())) {
+//                throw new IllegalArgumentException("가입된 휴대폰 번호가 아닙니다.");
+//            }
+
+            if (!isDuplicatedNameAndPhoneNumber(request.getName(), request.getPhoneNumber())) {
+                throw new IllegalArgumentException("해당 이름과 휴대폰 번호와 일치하는 계정이 존재하지 않습니다.");
             }
 
             smsService.sendSMS(request.getPhoneNumber());


### PR DESCRIPTION
- User의 Identity 변경
  - phoneNumber -> phoneNumber && Name Unique
- SMS API 일부 변경 및 휴대폰 번호 SMS API 추가(포스트맨 도큐먼트 확인 바람)
  - SendingType 명칭 일부 변경
  - name 변수 추가, accountId 변수 삭제
- SocialLogin 로직 수정
  - 카카오 소셜 로그인도 OICD로 수정
- 권한 범위 수정
  - 'GUEST'의 경우, 오직  소셜 로그인 프로필 정보 추가 API(api/users/extra-profile)만 인가 되도록 변경
- 유저 이미지를 null 값으로 넣을 시, 기존 이미지 데이터 삭제하는 로직 추가     